### PR TITLE
Add import/export symbols for MSVC.

### DIFF
--- a/dlfcn.h
+++ b/dlfcn.h
@@ -41,10 +41,18 @@ extern "C" {
 #define RTLD_DEFAULT    0
 #define RTLD_NEXT       0
 
-void *dlopen ( const char *file, int mode );
-int   dlclose( void *handle );
-void *dlsym  ( void *handle, const char *name );
-char *dlerror( void );
+#if defined (_MSC_VER)
+  #if defined (dl_EXPORTS)
+    #define DLFCN_EXPORT __declspec(dllexport)
+  #else
+    #define DLFCN_EXPORT __declspec(dllimport)
+  #endif
+#endif
+
+DLFCN_EXPORT void *dlopen ( const char *file, int mode );
+DLFCN_EXPORT int   dlclose( void *handle );
+DLFCN_EXPORT void *dlsym  ( void *handle, const char *name );
+DLFCN_EXPORT char *dlerror( void );
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When compiling the library with MS Visual Studio, a .lib file will be created and installed to lib/.