### PR TITLE
undefine DLFCN_WIN32_EXPORTS

### DIFF
--- a/dlfcn.c
+++ b/dlfcn.c
@@ -20,7 +20,6 @@
 #include <windows.h>
 #include <stdio.h>
 
-#define DLFCN_WIN32_EXPORTS
 #include "dlfcn.h"
 
 /* Note:


### PR DESCRIPTION
it should only passed by the build system when building shared libs
currently it doesn't allow to build static libs