### PR TITLE
configure: put test.{c,dll} to current directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,7 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# test files produced by ./configure
+tmptest.c
+tmptest.dll

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,11 @@ test: $(TARGETS) test.exe testdll.dll
 	$(WINE) test.exe
 
 clean::
-	rm -f dlfcn.o libdl.dll libdl.a libdl.def libdl.dll.a libdl.lib libdl.exp test.exe testdll.dll
+	rm -f \
+		dlfcn.o \
+		libdl.dll libdl.a libdl.def libdl.dll.a libdl.lib libdl.exp \
+		tmptest.c tmptest.dll \
+		test.exe testdll.dll
 
 distclean: clean
 	rm -f config.mak

--- a/configure
+++ b/configure
@@ -154,13 +154,13 @@ disabled shared && disabled static && {
 }
 
 # simple cc test
-cat > /tmp/test.c << EOF
+cat > tmptest.c << EOF
 #include <windows.h>
 void function(void)
 { LoadLibrary(NULL); }
 EOF
-echo testing compiler: $cc -shared -o /tmp/test.dll /tmp/test.c
-$cc -shared -o /tmp/test.dll /tmp/test.c
+echo testing compiler: $cc -shared -o tmptest.dll tmptest.c
+$cc -shared -o tmptest.dll tmptest.c
 
 test "$?" != 0 && {
     echo "$cc could not create shared file with Windows API functions.";


### PR DESCRIPTION
instead of /tmp/ to avoid races when building for multiple targets.