### PR TITLE
Add CMake code to export a CMake config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
 endif ()
 
-project (dlfcn C)
+project (dlfcn-win32 C)
 
 option(BUILD_SHARED_LIBS "shared/static libs" ON) 
 option(BUILD_TESTS "tests?" OFF)
@@ -19,11 +19,45 @@ endif (BUILD_SHARED_LIBS)
 add_library(dl ${sources})
 target_link_libraries(dl psapi)
 
-install (TARGETS dl RUNTIME DESTINATION bin
+install (TARGETS dl EXPORT dlfcn-win32-targets
+                    RUNTIME DESTINATION bin
                     LIBRARY DESTINATION lib${LIB_SUFFIX}
                     ARCHIVE DESTINATION lib${LIB_SUFFIX})
 
 install (FILES ${headers} DESTINATION include)
+
+# If CMake version is greater than or equal to 2.8.11
+# also install the cmake configuration files to simplify
+# the use of dlfcn-win32 in CMake
+if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.11")
+    # Correctly export the location of installed includes in the target 
+    target_include_directories(dl INTERFACE $<INSTALL_INTERFACE:include>)
+
+    # Export the targets  (build tree)
+    export(EXPORT dlfcn-win32-targets
+           FILE "${CMAKE_CURRENT_BINARY_DIR}/dlfcn-win32-targets.cmake"
+           NAMESPACE dlfcn-win32::
+    )
+    
+    # Write the CMake config file
+    set(CMAKE_CONF_INSTALL_DIR share/dlfcn-win32)
+    set(INCLUDE_INSTALL_DIR include)
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(dlfcn-win32-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/dlfcn-win32-config.cmake
+                                  INSTALL_DESTINATION ${CMAKE_CONF_INSTALL_DIR}
+                                  PATH_VARS INCLUDE_INSTALL_DIR
+                                  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+    # Install the targets (install)
+    install(EXPORT dlfcn-win32-targets
+            FILE dlfcn-win32-targets.cmake
+            NAMESPACE dlfcn-win32::
+            DESTINATION ${CMAKE_CONF_INSTALL_DIR})
+
+    # Install the CMake config file
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dlfcn-win32-config.cmake
+            DESTINATION ${CMAKE_CONF_INSTALL_DIR})
+endif()
 
 if (BUILD_TESTS)
   enable_testing()

--- a/dlfcn-win32-config.cmake.in
+++ b/dlfcn-win32-config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+set_and_check(dlfcn-win32_INCLUDEDIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+if(NOT TARGET dlfcn-win32::dl)
+  include(${CMAKE_CURRENT_LIST_DIR}/dlfcn-win32-targets.cmake)
+endif()
+
+set(dlfcn-win32_LIBRARIES dlfcn-win32::dl)
+set(dlfcn-win32_INCLUDE_DIRS ${dlfcn-win32_INCLUDEDIR})


### PR DESCRIPTION
This simplifies the use of the library for third-party CMake user, that just need to add a:
~~~
find_package(dlfcn-win32 REQUIRED)

...

target_link_libraries(<lib> dlfcn-win32::dl)
~~~

to use this library in their cmake project.

Furthermore this automatically links correctly the `Debug` or `Release` version depending on the configuration chosen by the downstream project in Visual Studio.

To get more info on CMake package config, check: https://cmake.org/cmake/help/v3.5/manual/cmake-packages.7.html .

Besides generating an additonal file, nothing else should change in the library. 