### PR TITLE
[test - do not merge] Try RTLD_NOW on msvc

### DIFF
--- a/test.c
+++ b/test.c
@@ -87,7 +87,7 @@ int main()
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
 #endif
 
-    library = dlopen( "testdll.dll", RTLD_GLOBAL );
+    library = dlopen( "testdll.dll", RTLD_NOW );
     if( !library )
     {
         error = dlerror( );


### PR DESCRIPTION
On MinGW using RTLD_NOW crashes when updating from 1.0.0 to 1.1.0