### PR TITLE
Fix bug in dlerror second consecutive call

### DIFF
--- a/dlfcn.c
+++ b/dlfcn.c
@@ -431,6 +431,12 @@ end:
 char *dlerror( void )
 {
     char *error_pointer = dlerror_buffer;
+    
+    /* If this is the second consecutive call to dlerror, return NULL */
+    if (current_error == NULL)
+    {
+        return NULL;
+    }
 
 #ifdef UNICODE
     errno_t err = 0;

--- a/test.c
+++ b/test.c
@@ -304,6 +304,21 @@ int main()
         error = dlerror( );
         printf( "SUCCESS\tCould not get nonexistent symbol from global handle: %s\n",
                 error ? error : "" );
+                
+        /* Test that the second call to dlerror() returns null as in the specs 
+           See https://github.com/dlfcn-win32/dlfcn-win32/issues/34 */
+        error = dlerror( );
+        if( error == NULL )
+        {
+            printf( "SUCCESS\tSecond consecutive call to dlerror returned NULL\n");
+        }
+        else 
+        {
+            printf( "ERROR\tSecond consecutive call to dlerror returned a non-NULL pointer: %p\n", error );
+            CLOSE_LIB;
+            CLOSE_GLOBAL;
+            RETURN_ERROR;
+        }
     }
 
     function = dlsym(global, "fwrite");


### PR DESCRIPTION
According to the specs, a second consecutive call to dlerror should always return NULL .
This was the case in dlfcn-win32 before https://github.com/dlfcn-win32/dlfcn-win32/pull/20 introduce a regression that caused dlerror to crash on the second consecutive call.

In this commit the issue is fixed as suggested in https://github.com/dlfcn-win32/dlfcn-win32/issues/34 and a regression test has been added.

Fix #34 . 

cc @TimothyGu @Fishkin @xantares @robertwgh