### PR TITLE
Correctly process malloc() error in dlsym()

### DIFF
--- a/dlfcn.c
+++ b/dlfcn.c
@@ -439,6 +439,11 @@ void *dlsym( void *handle, const char *name )
                 }
                 free( modules );
             }
+            else
+            {
+                SetLastError( ERROR_NOT_ENOUGH_MEMORY );
+                goto end;
+            }
         }
     }
 


### PR DESCRIPTION
malloc() may fail, so propagate this error to caller.