### PR TITLE
Show "(null)" in error message when passed filname to dlopen() was NULL and error occurred

### DIFF
--- a/dlfcn.c
+++ b/dlfcn.c
@@ -233,7 +233,7 @@ void *dlopen( const char *file, int mode )
         hModule = GetModuleHandle( NULL );
 
         if( !hModule )
-            save_err_ptr_str( file );
+            save_err_str( "(null)" );
     }
     else
     {


### PR DESCRIPTION
It does not make sense to pass file variable (which is NULL) to function
save_err_ptr_str() which converts its argument to string. We can call
directly save_err_str() with string value.

Also it is highly unexpected that GetModuleHandle(NULL) call fails.