### PR TITLE
Add support for wide character version of "dlopen", namely "wdlopen".

### DIFF
--- a/dlfcn.c
+++ b/dlfcn.c
@@ -208,6 +208,157 @@ static BOOL MyEnumProcessModules( HANDLE hProcess, HMODULE *lphModule, DWORD cb,
     return EnumProcessModulesPtr( hProcess, lphModule, cb, lpcbNeeded );
 }
 
+// Create a converted multibyte character string from a wide character string.
+static char *utf8_encode( const wchar_t *wstr )
+{
+    size_t input_str_len = wcslen( wstr );
+    if ( !wstr || input_str_len == 0 )
+    {
+        return NULL;
+    }
+    int size_needed = WideCharToMultiByte( CP_UTF8, 0, wstr, input_str_len, NULL, 0, NULL, NULL );
+    char *to_return = (char *) malloc( size_needed * sizeof( char ) );
+    if ( !to_return )
+        return NULL;
+    WideCharToMultiByte( CP_UTF8, 0, wstr, input_str_len, to_return, size_needed, NULL, NULL );
+    return to_return;
+}
+
+// Create a converted wide character string from a multibyte character string.
+static wchar_t *utf8_decode( const char *str )
+{
+    size_t input_str_len = strlen( str );
+    if ( !str || input_str_len == 0 )
+    {
+        return NULL;
+    }
+    int size_needed = MultiByteToWideChar( CP_UTF8, 0, str, input_str_len, NULL, 0 );
+    wchar_t *to_return = (wchar_t *) malloc( size_needed * sizeof( wchar_t ) );
+    if ( !to_return )
+        return NULL;
+    MultiByteToWideChar( CP_UTF8, 0, str, input_str_len, to_return, size_needed );
+    return to_return;
+}
+
+void *wdlopen( const wchar_t *file, int mode )
+{
+    HMODULE hModule;
+    UINT uMode;
+
+    error_occurred = FALSE;
+
+    /* Do not let Windows display the critical-error-handler message box */
+    uMode = SetErrorMode( SEM_FAILCRITICALERRORS );
+
+    if( file == 0 )
+    {
+        /* POSIX says that if the value of file is 0, a handle on a global
+         * symbol object must be provided. That object must be able to access
+         * all symbols from the original program file, and any objects loaded
+         * with the RTLD_GLOBAL flag.
+         * The return value from GetModuleHandle( ) allows us to retrieve
+         * symbols only from the original program file. EnumProcessModules() is
+         * used to access symbols from other libraries. For objects loaded
+         * with the RTLD_LOCAL flag, we create our own list later on. They are
+         * excluded from EnumProcessModules() iteration.
+         */
+        hModule = GetModuleHandle( NULL );
+
+        if( !hModule )
+            save_err_str( "(null)" );
+    }
+    else
+    {
+        HANDLE hCurrentProc;
+        DWORD dwProcModsBefore, dwProcModsAfter;
+        wchar_t lpFileName[MAX_PATH];
+        size_t i, len;
+
+        len = wcslen( file );
+
+        if( len >= sizeof( lpFileName ) )
+        {
+            SetLastError( ERROR_FILENAME_EXCED_RANGE );
+            char* fileMultibyte = utf8_encode( file );
+            if ( !fileMultibyte )
+                return NULL;
+            save_err_str( fileMultibyte );
+            free( fileMultibyte );
+            hModule = NULL;
+        }
+        else
+        {
+            /* MSDN says backslashes *must* be used instead of forward slashes. */
+            for( i = 0; i < len; i++ )
+            {
+                if( file[i] == '/' )
+                    lpFileName[i] = '\\';
+                else
+                    lpFileName[i] = file[i];
+            }
+            lpFileName[len] = '\0';
+
+            hCurrentProc = GetCurrentProcess( );
+
+            if( MyEnumProcessModules( hCurrentProc, NULL, 0, &dwProcModsBefore ) == 0 )
+                dwProcModsBefore = 0;
+
+            /* POSIX says the search path is implementation-defined.
+             * LOAD_WITH_ALTERED_SEARCH_PATH is used to make it behave more closely
+             * to UNIX's search paths (start with system folders instead of current
+             * folder).
+             */
+            hModule = LoadLibraryExW( lpFileName, NULL, LOAD_WITH_ALTERED_SEARCH_PATH );
+
+            if( !hModule )
+            {
+                char* lpFileNameMultibyte = utf8_encode( lpFileName );
+                if ( !lpFileNameMultibyte )
+                    return NULL;
+                save_err_str( lpFileNameMultibyte );
+                free( lpFileNameMultibyte );
+            }
+            else
+            {
+                if( MyEnumProcessModules( hCurrentProc, NULL, 0, &dwProcModsAfter ) == 0 )
+                    dwProcModsAfter = 0;
+
+                /* If the object was loaded with RTLD_LOCAL, add it to list of local
+                 * objects, so that its symbols cannot be retrieved even if the handle for
+                 * the original program file is passed. POSIX says that if the same
+                 * file is specified in multiple invocations, and any of them are
+                 * RTLD_GLOBAL, even if any further invocations use RTLD_LOCAL, the
+                 * symbols will remain global. If number of loaded modules was not
+                 * changed after calling LoadLibraryEx(), it means that library was
+                 * already loaded.
+                 */
+                if( (mode & RTLD_LOCAL) && dwProcModsBefore != dwProcModsAfter )
+                {
+                    if( !local_add( hModule ) )
+                    {
+                        char* lpFileNameMultibyte = utf8_encode( lpFileName );
+                        if ( !lpFileNameMultibyte )
+                            return NULL;
+                        save_err_str( lpFileNameMultibyte );
+                        free( lpFileNameMultibyte );
+                        FreeLibrary( hModule );
+                        hModule = NULL;
+                    }
+                }
+                else if( !(mode & RTLD_LOCAL) && dwProcModsBefore == dwProcModsAfter )
+                {
+                    local_rem( hModule );
+                }
+            }
+        }
+    }
+
+    /* Return to previous state of the error-mode bit flags. */
+    SetErrorMode( uMode );
+
+    return (void *) hModule;
+}
+
 void *dlopen( const char *file, int mode )
 {
     HMODULE hModule;

--- a/dlfcn.h
+++ b/dlfcn.h
@@ -30,6 +30,8 @@ extern "C" {
 #   define DLFCN_EXPORT
 #endif
 
+#include <wchar.h>
+
 /* Relocations are performed when the object is loaded. */
 #define RTLD_NOW    0
 
@@ -55,7 +57,10 @@ extern "C" {
 /* Specifies the next object after this one that defines name. */
 #define RTLD_NEXT       ((void *)-1)
 
-/* Open a symbol table handle. */
+/* Open a symbol table handle (file path is in wide character). */
+DLFCN_EXPORT void *wdlopen(const wchar_t *file, int mode);
+
+/* Open a symbol table handle (ASCII file path only). */
 DLFCN_EXPORT void *dlopen(const char *file, int mode);
 
 /* Close a symbol table handle. */


### PR DESCRIPTION
- Adding a new version of "dlopen", called "wdlopen", that accepts wide character file paths input to be used, say, for UTF-8 named DLL file paths.