### PR TITLE
Fix compilation with older environments

### DIFF
--- a/dlfcn.c
+++ b/dlfcn.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0501
+#endif
 #ifdef _DEBUG
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>


### PR DESCRIPTION
This change should fix following compile error:

    dlfcn.c: In function 'dlsym':
    dlfcn.c:374:14: warning: implicit declaration of function 'GetModuleHandleExA'
    dlfcn.c: undefined reference to `GetModuleHandleExA'

Documentation for function GetModuleHandleExA() says:

    To compile an application that uses this function, define _WIN32_WINNT as 0x0501 or later.

Fixes: https://github.com/dlfcn-win32/dlfcn-win32/issues/75