### PR TITLE
Change order of variables in appveyor build matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,191 +26,191 @@
 
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: ON
       cc_path: 'C:\MinGW\bin'
-      BUILD_SHARED_LIBS: ON
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: ON
       cc_path: 'C:\MinGW\bin'
-      BUILD_SHARED_LIBS: ON
       CFLAGS: '-DUNICODE -D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: OFF
       cc_path: 'C:\MinGW\bin'
-      BUILD_SHARED_LIBS: OFF
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: OFF
+      CFLAGS: '-DUNICODE -D_UNICODE'
       cc_path: 'C:\MinGW\bin'
-      BUILD_SHARED_LIBS: OFF
-      CFLAGS: '-DUNICODE -D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: ON
       cc_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
-      BUILD_SHARED_LIBS: ON
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: ON
+      CFLAGS: '-DUNICODE -D_UNICODE'
       cc_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
-      BUILD_SHARED_LIBS: ON
-      CFLAGS: '-DUNICODE -D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: OFF
       cc_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
-      BUILD_SHARED_LIBS: OFF
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: OFF
+      CFLAGS: '-DUNICODE -D_UNICODE'
       cc_path: 'C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin'
-      BUILD_SHARED_LIBS: OFF
-      CFLAGS: '-DUNICODE -D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: ON
       cc_path: 'C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin'
-      BUILD_SHARED_LIBS: ON
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: ON
+      CFLAGS: '-DUNICODE -D_UNICODE'
       cc_path: 'C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin'
-      BUILD_SHARED_LIBS: ON
-      CFLAGS: '-DUNICODE -D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: OFF
       cc_path: 'C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin'
-      BUILD_SHARED_LIBS: OFF
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: OFF
+      CFLAGS: '-DUNICODE -D_UNICODE'
       cc_path: 'C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin'
-      BUILD_SHARED_LIBS: OFF
-      CFLAGS: '-DUNICODE -D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: ON
       cc_path: 'C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin'
-      BUILD_SHARED_LIBS: ON
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: ON
+      CFLAGS: '-DUNICODE -D_UNICODE'
       cc_path: 'C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin'
-      BUILD_SHARED_LIBS: ON
-      CFLAGS: '-DUNICODE -D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: OFF
       cc_path: 'C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin'
-      BUILD_SHARED_LIBS: OFF
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
+    - GENERATOR: "MinGW Makefiles"
+      BUILD_SHARED_LIBS: OFF
+      CFLAGS: '-DUNICODE -D_UNICODE'
       cc_path: 'C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin'
-      BUILD_SHARED_LIBS: OFF
-      CFLAGS: '-DUNICODE -D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
-      cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+    - GENERATOR: "MinGW Makefiles"
       BUILD_SHARED_LIBS: ON
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
       cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - GENERATOR: "MinGW Makefiles"
       BUILD_SHARED_LIBS: ON
       CFLAGS: '-DUNICODE -D_UNICODE'
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
       cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - GENERATOR: "MinGW Makefiles"
       BUILD_SHARED_LIBS: OFF
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
       cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - GENERATOR: "MinGW Makefiles"
       BUILD_SHARED_LIBS: OFF
       CFLAGS: '-DUNICODE -D_UNICODE'
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "MinGW Makefiles"
       cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - GENERATOR: "MinGW Makefiles"
       BUILD_SHARED_LIBS: ON
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "MinGW Makefiles"
       cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - GENERATOR: "MinGW Makefiles"
       BUILD_SHARED_LIBS: ON
       CFLAGS: '-DUNICODE -D_UNICODE'
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "MinGW Makefiles"
       cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - GENERATOR: "MinGW Makefiles"
       BUILD_SHARED_LIBS: OFF
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "MinGW Makefiles"
       cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - GENERATOR: "MinGW Makefiles"
       BUILD_SHARED_LIBS: OFF
       CFLAGS: '-DUNICODE -D_UNICODE'
+      cc_path: 'C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "Visual Studio 15 2017"
+    - GENERATOR: "Visual Studio 15 2017"
       BUILD_SHARED_LIBS: ON
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "Visual Studio 15 2017"
-      BUILD_SHARED_LIBS: ON
-      CFLAGS: '/DUNICODE /D_UNICODE'
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "Visual Studio 15 2017"
-      BUILD_SHARED_LIBS: OFF
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "Visual Studio 15 2017"
-      BUILD_SHARED_LIBS: OFF
-      CFLAGS: '/DUNICODE /D_UNICODE'
-  
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015"
-      BUILD_SHARED_LIBS: ON
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015"
+    - GENERATOR: "Visual Studio 15 2017"
       BUILD_SHARED_LIBS: ON
       CFLAGS: '/DUNICODE /D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015"
+    - GENERATOR: "Visual Studio 15 2017"
       BUILD_SHARED_LIBS: OFF
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015"
+    - GENERATOR: "Visual Studio 15 2017"
       BUILD_SHARED_LIBS: OFF
       CFLAGS: '/DUNICODE /D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 12 2013"
+    - GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: ON
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 12 2013"
+    - GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: ON
       CFLAGS: '/DUNICODE /D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 12 2013"
+    - GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: OFF
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 12 2013"
+    - GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: OFF
       CFLAGS: '/DUNICODE /D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - GENERATOR: "Visual Studio 12 2013"
+      BUILD_SHARED_LIBS: ON
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - GENERATOR: "Visual Studio 12 2013"
+      BUILD_SHARED_LIBS: ON
+      CFLAGS: '/DUNICODE /D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - GENERATOR: "Visual Studio 12 2013"
+      BUILD_SHARED_LIBS: OFF
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - GENERATOR: "Visual Studio 12 2013"
+      BUILD_SHARED_LIBS: OFF
+      CFLAGS: '/DUNICODE /D_UNICODE'
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 platform:
   - Win32


### PR DESCRIPTION
This change no function effect as it changes only order of defined
variables. The only visible change is on appveyor web where variables are
printed in other as they are defined. If list of variables is too long,
variables defined later are hidden on the web interface. Variable
APPVEYOR_BUILD_WORKER_IMAGE was moved to the end of list as it is less
important to know as variable GENERATOR (defines which compiler is used).