### PR TITLE
Run Travis tests also under i586-mingw32msvc-gcc compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,18 @@ env:
   - ci_buildsys=cmake
   - ci_buildsys=Makefile
 
+jobs:
+  include:
+    - dist: trusty
+      compiler: i586-mingw32msvc-gcc
+      addons:
+        apt:
+          packages:
+            - mingw32
+            - wine
+      env: ci_buildsys=Makefile
+      # Check that we have a real i586-mingw32msvc-gcc compiler as sometimes it is just a symlink to i686-w64-mingw32-gcc
+      before_script: "i586-mingw32msvc-gcc -v 2>&1 | grep -q -x 'Target: i586-mingw32msvc'"
+
 script:
   - ci_target=${CC%-*} ./tools/ci-build.sh

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -11,8 +11,6 @@ set -x
 # target to build for
 : "${ci_target:=${CROSS_COMPILE%-}}"
 
-install_prefix=$(${ci_target}-gcc --print-sysroot)/${ci_target}
-
 case "$ci_buildsys" in
     (Makefile)
         ./configure --enable-shared --enable-static --enable-wine --cross-prefix=${ci_target}-
@@ -27,7 +25,7 @@ case "$ci_buildsys" in
         cd build
         cmake \
             --no-warn-unused-cli                         \
-            -DCMAKE_FIND_ROOT_PATH=$install_prefix       \
+            -DCMAKE_FIND_ROOT_PATH=$(${ci_target}-gcc --print-sysroot)/${ci_target}       \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo            \
             -DCMAKE_C_COMPILER=$(which ${ci_target}-gcc) \
             -DCMAKE_SYSTEM_PROCESSOR=${ci_target%-*-*}   \


### PR DESCRIPTION
Beware that i586-mingw32msvc-gcc is sometimes just a symlink to
i686-w64-mingw32-gcc. Real i586-mingw32msvc-gcc compiler is available in
mingw32 package only in dist trusty.