### PR TITLE
Add _CRT_SECURE_NO_WARNINGS for test.c to disable MSVC deprecation warnings

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  */
 
+#define _CRT_SECURE_NO_WARNINGS
 #ifdef _DEBUG
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>


### PR DESCRIPTION
* warning C4996: '_open': This function or variable may be unsafe.
* warning C4996: 'strerror': This function or variable may be unsafe.
* warning C4996: 'wcscpy': This function or variable may be unsafe.
* warning C4996: '_wopen': This function or variable may be unsafe.