### PR TITLE
Various fixes

### DIFF
--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -33,6 +33,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* Older versions do not have this type */
+#if _WIN32_WINNT < 0x0500
+typedef ULONG ULONG_PTR;
+#endif
+
 /* Older SDK versions do not have these macros */
 #ifndef GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
 #define GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS 0x4

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -61,6 +61,16 @@ typedef ULONG ULONG_PTR;
 #endif
 #include "dlfcn.h"
 
+#if defined( _MSC_VER ) && _MSC_VER >= 1300
+/* https://docs.microsoft.com/en-us/cpp/cpp/noinline */
+#define DLFCN_NOINLINE __declspec( noinline )
+#elif defined( __GNUC__ ) && ( ( __GNUC__ > 3 ) || ( __GNUC__ == 3 && __GNUC_MINOR__ >= 1 ) )
+/* https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html */
+#define DLFCN_NOINLINE __attribute__(( noinline ))
+#else
+#define DLFCN_NOINLINE
+#endif
+
 /* Note:
  * MSDN says these functions are not thread-safe. We make no efforts to have
  * any kind of thread safety.
@@ -418,7 +428,7 @@ int dlclose( void *handle )
     return (int) ret;
 }
 
-__declspec(noinline) /* Needed for _ReturnAddress() */
+DLFCN_NOINLINE /* Needed for _ReturnAddress() */
 DLFCN_EXPORT
 void *dlsym( void *handle, const char *name )
 {

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -362,14 +362,12 @@ void *dlsym( void *handle, const char *name )
     FARPROC symbol;
     HMODULE hCaller;
     HMODULE hModule;
-    HANDLE hCurrentProc;
 
     error_occurred = FALSE;
 
     symbol = NULL;
     hCaller = NULL;
     hModule = GetModuleHandle( NULL );
-    hCurrentProc = GetCurrentProcess( );
 
     if( handle == RTLD_DEFAULT )
     {
@@ -407,10 +405,13 @@ void *dlsym( void *handle, const char *name )
 
     if( hModule == handle || handle == RTLD_NEXT )
     {
+        HANDLE hCurrentProc;
         HMODULE *modules;
         DWORD cbNeeded;
         DWORD dwSize;
         size_t i;
+
+        hCurrentProc = GetCurrentProcess( );
 
         /* GetModuleHandle( NULL ) only returns the current program file. So
          * if we want to get ALL loaded module including those in linked DLLs,

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -192,7 +192,7 @@ static void save_err_ptr_str( const void *ptr, DWORD dwMessageId )
 
     for( i = 0; i < 2 * sizeof( ptr ); i++ )
     {
-        num = ( ( (ULONG_PTR) ptr ) >> ( 8 * sizeof( ptr ) - 4 * ( i + 1 ) ) ) & 0xF;
+        num = (char) ( ( ( (ULONG_PTR) ptr ) >> ( 8 * sizeof( ptr ) - 4 * ( i + 1 ) ) ) & 0xF );
         ptr_buf[2 + i] = num + ( ( num < 0xA ) ? '0' : ( 'A' - 0xA ) );
     }
 

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -38,11 +38,11 @@
 
 #ifdef _MSC_VER
 /* https://docs.microsoft.com/en-us/cpp/intrinsics/returnaddress */
-#pragma intrinsic(_ReturnAddress)
+#pragma intrinsic( _ReturnAddress )
 #else
 /* https://gcc.gnu.org/onlinedocs/gcc/Return-Address.html */
 #ifndef _ReturnAddress
-#define _ReturnAddress() (__builtin_extract_return_addr(__builtin_return_address(0)))
+#define _ReturnAddress( ) ( __builtin_extract_return_addr( __builtin_return_address( 0 ) ) )
 #endif
 #endif
 
@@ -90,12 +90,12 @@ static BOOL local_add( HMODULE hModule )
     pobject = local_search( hModule );
 
     /* Do not add object again if it's already on the list */
-    if( pobject )
+    if( pobject != NULL )
         return TRUE;
 
     for( pobject = &first_object; pobject->next; pobject = pobject->next );
 
-    nobject = (local_object*) malloc( sizeof( local_object ) );
+    nobject = (local_object *) malloc( sizeof( local_object ) );
 
     if( !nobject )
     {
@@ -120,7 +120,7 @@ static void local_rem( HMODULE hModule )
 
     pobject = local_search( hModule );
 
-    if( !pobject )
+    if( pobject == NULL )
         return;
 
     if( pobject->next )
@@ -159,7 +159,7 @@ static void save_err_str( const char *str )
       */
     pos = 0;
     error_buffer[pos++] = '"';
-    memcpy( error_buffer+pos, str, len );
+    memcpy( error_buffer + pos, str, len );
     pos += len;
     error_buffer[pos++] = '"';
     error_buffer[pos++] = ':';
@@ -167,7 +167,7 @@ static void save_err_str( const char *str )
 
     ret = FormatMessageA( FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dwMessageId,
         MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ),
-        error_buffer+pos, (DWORD) (sizeof(error_buffer)-pos), NULL );
+        error_buffer + pos, (DWORD) ( sizeof( error_buffer ) - pos ), NULL );
     pos += ret;
 
     /* When FormatMessageA() fails it returns zero and does not touch buffer
@@ -197,7 +197,7 @@ static void save_err_ptr_str( const void *ptr )
     for( i = 0; i < 2 * sizeof( ptr ); i++ )
     {
         num = ( ( (ULONG_PTR) ptr ) >> ( 8 * sizeof( ptr ) - 4 * ( i + 1 ) ) ) & 0xF;
-        ptr_buf[2+i] = num + ( ( num < 0xA ) ? '0' : ( 'A' - 0xA ) );
+        ptr_buf[2 + i] = num + ( ( num < 0xA ) ? '0' : ( 'A' - 0xA ) );
     }
 
     ptr_buf[2 + 2 * sizeof( ptr )] = 0;
@@ -234,9 +234,9 @@ void *dlopen( const char *file, int mode )
     /* Do not let Windows display the critical-error-handler message box */
     uMode = SetErrorMode( SEM_FAILCRITICALERRORS );
 
-    if( file == 0 )
+    if( file == NULL )
     {
-        /* POSIX says that if the value of file is 0, a handle on a global
+        /* POSIX says that if the value of file is NULL, a handle on a global
          * symbol object must be provided. That object must be able to access
          * all symbols from the original program file, and any objects loaded
          * with the RTLD_GLOBAL flag.

--- a/tests/test.c
+++ b/tests/test.c
@@ -342,7 +342,7 @@ int main()
     *(void **) (&fwrite_local) = dlsym( global, "fwrite" );
     if (!fwrite_local)
     {
-        error = dlerror();
+        error = dlerror( );
         printf("ERROR\tCould not get symbol from global handle: %s\n",
             error ? error : "");
         CLOSE_LIB;
@@ -360,7 +360,7 @@ int main()
     *(void **) (&fputs_default) = dlsym( RTLD_DEFAULT, "fputs" );
     if (!fputs_default)
     {
-        error = dlerror();
+        error = dlerror( );
         printf("ERROR\tCould not get symbol from default handle: %s\n",
             error ? error : "");
         CLOSE_LIB;
@@ -623,7 +623,7 @@ int main()
     *(void **) (&function) = dlsym( global, "fwrite" );
     if (!function)
     {
-        error = dlerror();
+        error = dlerror( );
         printf("ERROR\tCould not get symbol from global handle: %s\n",
             error ? error : "");
         CLOSE_LIB;
@@ -659,7 +659,7 @@ int main()
     *(void **) (&function) = dlsym( global, "function3" );
     if (!function)
     {
-        error = dlerror();
+        error = dlerror( );
         printf("ERROR\tCould not get symbol from global handle: %s\n",
             error ? error : "");
         CLOSE_LIB;


### PR DESCRIPTION
This pull request contains various fixes for different MSVC and gcc compilers, different Windows versions and also for different compile environment (WDK, _WIN32_WINNT, ...). With these changes, dlfcn-win32 compiles without issues also in Visual Studio 6.0, also in WDK 6001.18002 and also for Windows 7 (K32EnumProcessModules). Compiled library/executable should have same functionality independently of used compiler and chosen target environment.