### PR TITLE
cmake: bump version to 3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.2)
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")


### PR DESCRIPTION
this silences a warning with newer cmake versions 
cmake 3.2 was released in 2015 should be available in most distros