### PR TITLE
add new lines to links to workaround github Markdown render

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ Windows without any modifications.
 It follows the standard as described here:
 
 http://www.opengroup.org/onlinepubs/009695399/basedefs/dlfcn.h.html
+
 http://www.opengroup.org/onlinepubs/009695399/functions/dlerror.html
+
 http://www.opengroup.org/onlinepubs/009695399/functions/dlsym.html
+
 http://www.opengroup.org/onlinepubs/009695399/functions/dlclose.html
+
 http://www.opengroup.org/onlinepubs/009695399/functions/dlopen.html
 
 Using This Library


### PR DESCRIPTION
adding lines like

```
line1
line2
```

results in github merging those lines

```
line1 line2
```

the correct result is obtained by adding an additional new line

```
line1

line2
```

which results in

```
line1
line2
```