### PR TITLE
Fix CMake include directive when using wrappers like meson.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,10 @@ set(sources dlfcn.c)
 add_library(dl ${sources})
 
 # Correctly export the location of installed includes in the target
-target_include_directories(dl INTERFACE $<INSTALL_INTERFACE:include>)
+target_include_directories(dl
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>)
 
 # dot not add -D<target>_EXPORTS
 set_target_properties(dl PROPERTIES DEFINE_SYMBOL "")


### PR DESCRIPTION
When using the CMake wrapper from Meson the build fails, as the `include` directory does not get recognized.

This patch here is the common CMake way of linking header files to a library. Most projects would use `$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>` as the headers are commonly placed there. Moving the header might be worth considering, but as it stands it works just fine.