### PR TITLE
Add missing check that section index in get_image_section() is valid

### DIFF
--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -640,7 +640,7 @@ static BOOL get_image_section( HMODULE module, int index, void **ptr, DWORD *siz
     if( optionalHeader->Magic != IMAGE_NT_OPTIONAL_HDR_MAGIC )
         return FALSE;
 
-    if( index < 0 || index >= IMAGE_NUMBEROF_DIRECTORY_ENTRIES )
+    if( index < 0 || index >= IMAGE_NUMBEROF_DIRECTORY_ENTRIES || index >= optionalHeader->NumberOfRvaAndSizes )
         return FALSE;
 
     if( optionalHeader->DataDirectory[index].Size == 0 || optionalHeader->DataDirectory[index].VirtualAddress == 0 )


### PR DESCRIPTION
Number is stored in NumberOfRvaAndSizes and it may be less than IMAGE_NUMBEROF_DIRECTORY_ENTRIES.