### PR TITLE
Allow dlsym( RTDL_NEXT, "malloc" ) to be called

### DIFF
--- a/src/dlfcn.h
+++ b/src/dlfcn.h
@@ -25,8 +25,17 @@
 #define DLFCN_H
 
 #ifdef __cplusplus
+#include <csetjmp>
+#define EXEC_CXX_FORK(JMPBUF)        std::setjmp(JMPBUF)
+#define EXIT_CXX_FORK(JMPBUF,STATUS) std::longjmp(JMPBUF,STATUS)
 extern "C" {
+#else
+#include <setjmp.h>
 #endif
+
+/* Defined to make things less confusing when find the calls in code */
+#define EXEC_C_FORK(JMPBUF)        setjmp(JMPBUF)
+#define EXIT_C_FORK(JMPBUF,STATUS) longjmp(JMPBUF,STATUS)
 
 #if defined(DLFCN_WIN32_SHARED)
 #if defined(DLFCN_WIN32_EXPORTS)


### PR DESCRIPTION
I have not checked if RTDL_NEXT is even defined but this prevents an infinite recursion of calling malloc should wrappers like the one in the below url be made:

https://www.youtube.com/watch?v=RoVD6zlftF0

Note this is my 1st attempt at submitting a patch/pull request so forgive any mistakes on that side of things. I don't think I made any mistakes in the code but if I did you can easily fix that with what you can see from this pull request anyways.