### PR TITLE
Fix compatibility with CMake 4.0 by bumping policy_max in cmake_minimum_required to 3.10 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11...3.2)
+cmake_minimum_required(VERSION 2.8.11...3.10)
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")


### PR DESCRIPTION
Fix https://github.com/dlfcn-win32/dlfcn-win32/issues/116 .