### PR TITLE
Do not link CRT for non-debug DLL builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ libdl.a: $(SOURCES)
 	$(RANLIB) $@
 
 libdl.dll: $(SOURCES)
-	$(CC) $(CFLAGS) $(SHFLAGS) -DDLFCN_WIN32_SHARED -shared -o $@ $^
+	$(CC) $(CFLAGS) $(SHFLAGS) -DDLFCN_WIN32_SHARED -DDLFCN_WIN32_SHARED_ENTRYPOINT -D_DllMainCRTStartup=DllMainCRTStartup -nostartfiles -nostdlib -shared -o $@ $^ -lkernel32
 
 libdl.lib: libdl.dll
 	$(LIBCMD) /machine:i386 /def:libdl.def

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,14 @@ set_target_properties(dl PROPERTIES DEFINE_SYMBOL "")
 
 # set shared mode for compiling library and propagate mode to cmake clients
 if (BUILD_SHARED_LIBS)
+    # for non-debug shared mode, avoid linking to CRT library as it is not needed
+    if (MSVC)
+        set_property(TARGET dl APPEND PROPERTY COMPILE_OPTIONS $<$<NOT:$<CONFIG:Debug>>:/Zl /GS->)
+    else (MSVC)
+        set_property(TARGET dl APPEND PROPERTY COMPILE_DEFINITIONS $<$<NOT:$<CONFIG:Debug>>:_DllMainCRTStartup=DllMainCRTStartup>)
+        set_property(TARGET dl APPEND PROPERTY LINK_OPTIONS $<$<NOT:$<CONFIG:Debug>>:-nostartfiles -nostdlib -lkernel32>)
+    endif (MSVC)
+    set_property(TARGET dl APPEND PROPERTY COMPILE_DEFINITIONS $<$<NOT:$<CONFIG:Debug>>:DLFCN_WIN32_SHARED_ENTRYPOINT>)
     target_compile_definitions(dl PUBLIC DLFCN_WIN32_SHARED)
 endif (BUILD_SHARED_LIBS)
 

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -24,6 +24,10 @@
  * THE SOFTWARE.
  */
 
+#ifdef _MSC_VER
+#pragma comment( lib, "KERNEL32" )
+#endif
+
 #ifdef _DEBUG
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h> /* malloc() and free() */

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -103,23 +103,17 @@ __declspec( naked ) static void *_ReturnAddress( void ) { __asm mov eax, [ebp+4]
 #define DLFCN_NOINLINE
 #endif
 
-static void *MyAlloc( size_t size )
-{
+/* Do not define MyAlloc and MyFree as functions because it breaks memory
+ * allocation file name and line number tracking. In debug mode is "malloc"
+ * defined as macro which pass __FILE__ and __LINE__ to helper function.
+ */
 #ifdef _DEBUG
-    return malloc( size );
+#define MyAlloc( size ) malloc( size )
+#define MyFree( ptr ) free( ptr )
 #else
-    return LocalAlloc( LPTR, size );
+#define MyAlloc( size ) LocalAlloc( LPTR, size )
+#define MyFree( ptr ) LocalFree( ptr )
 #endif
-}
-
-static void MyFree( void *ptr )
-{
-#ifdef _DEBUG
-    free( ptr );
-#else
-    LocalFree( ptr );
-#endif
-}
 
 /* Note:
  * MSDN says these functions are not thread-safe. We make no efforts to have

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -78,9 +78,30 @@ extern "C" void *_ReturnAddress(void);
  * because inline assembly does not have a return value, put it into naked
  * function which does not have prologue and epilogue and preserve registers.
  * When compiling in C++ mode, it is required to have C declaration for _alloca.
+ * For using _alloca, it is required to include default CRT library, which name
+ * can be deduced from _DLL, _MT and _DEBUG preprocessor macros.
  */
 #ifdef __cplusplus
 extern "C" void *__cdecl _alloca(size_t);
+#endif
+#if defined( _DLL )
+#ifdef _DEBUG
+#pragma comment( lib, "MSVCRTD" )
+#else
+#pragma comment( lib, "MSVCRT" )
+#endif
+#elif defined( _MT )
+#ifdef _DEBUG
+#pragma comment( lib, "LIBCMTD" )
+#else
+#pragma comment( lib, "LIBCMT" )
+#endif
+#else
+#ifdef _DEBUG
+#pragma comment( lib, "LIBCD" )
+#else
+#pragma comment( lib, "LIBC" )
+#endif
 #endif
 __declspec( naked ) static void *_ReturnAddress( void ) { __asm mov eax, [ebp+4] __asm ret }
 #define _ReturnAddress( ) ( _alloca(1), _ReturnAddress( ) )

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -955,4 +955,15 @@ BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved )
     (void) lpvReserved;
     return TRUE;
 }
+
+/* When requested defines DLL entry point which avoids using CRT library */
+#ifdef DLFCN_WIN32_SHARED_ENTRYPOINT
+#ifdef __cplusplus
+extern "C"
+#endif
+BOOL WINAPI _DllMainCRTStartup( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved )
+{
+    return DllMain( hinstDLL, fdwReason, lpvReserved );
+}
+#endif
 #endif

--- a/tests/test.c
+++ b/tests/test.c
@@ -204,7 +204,11 @@ int main()
         RETURN_ERROR;
     }
     else
+    {
+        char *error_without_name = strchr( error, ':' );
+        error = error_without_name ? ( error_without_name + 2 ) : error;
         printf( "SUCCESS\tCould not open file with too long file name: %s\n", error );
+    }
 
     uMode = SetErrorMode( SEM_FAILCRITICALERRORS );
     library3 = LoadLibraryA( toolongfile );

--- a/tests/test.c
+++ b/tests/test.c
@@ -683,7 +683,12 @@ int main()
         printf( "SUCCESS\tClosed global handle.\n" );
 
 #ifdef _DEBUG
-    _CrtDumpMemoryLeaks();
+    ret = _CrtDumpMemoryLeaks();
+    if( ret )
+    {
+        printf( "ERROR\tMemory leak\n" );
+        RETURN_ERROR;
+    }
 #endif
     return 0;
 }


### PR DESCRIPTION
Another contribution from @pali . Main modifications point:

> Usage of _alloca emits __alloca_probe call by msvc compiler which is
present in msvc LIBC library. So when _alloca is used then force linker to
include LIBC library. Correct name of the LIBC library is determined by
_DLL, _MT and _DEBUG preprocessor macros.

and

> Now when dlfcn.c does not call any function from CRT library, it is not
needed to link dlfcn library with some specific CRT library (e.g.
crtdll.dll, msvcrt.dll, msvcr120.dll or api-ms-win-crt-*.dll) and therefore
bound the dlfcn DLL library to specific Visual C++ runtime version.
>
> This makes libdl.dll DLL library CRT-neutral and therefore can be used or
linked into any EXE application using any CRT library of any version,
without any Visual C++ runtime version conflict.